### PR TITLE
Add attribute to have aliases listed on cakebuild.net

### DIFF
--- a/Cake.ArgumentBinder/ArgumentBinderAliases.cs
+++ b/Cake.ArgumentBinder/ArgumentBinderAliases.cs
@@ -1,0 +1,15 @@
+﻿//
+// Copyright Seth Hendrick 2019.
+// Distributed under the MIT License.
+// (See accompanying file LICENSE in the root of the repository).
+//
+
+using Cake.Core.Annotations;
+
+namespace Cake.ArgumentBinder
+{
+    [CakeAliasCategory("Arguments")]
+    public static partial class ArgumentBinderAliases
+    {
+    }
+}


### PR DESCRIPTION
Add required attribute to have aliases listed on cakebuild.net. This will list aliases on the reference page at https://cakebuild.net/dsl/arguments/ and on the alias details page at https://cakebuild.net/extensions/cake-argumentbinder/