### PR TITLE
Upgrade Cake.ArgumentBinder to target Cake 2.0.0 and .NET Core 3.1.

### DIFF
--- a/Examples/DeleteHelpers.cake
+++ b/Examples/DeleteHelpers.cake
@@ -1,5 +1,5 @@
 //
-// Copyright Seth Hendrick 2019-2021.
+// Copyright Seth Hendrick 2019-2022.
 // Distributed under the MIT License.
 // (See accompanying file LICENSE in the root of the repository).
 //

--- a/Examples/Figlet.cake
+++ b/Examples/Figlet.cake
@@ -1,5 +1,5 @@
 //
-// Copyright Seth Hendrick 2019-2021.
+// Copyright Seth Hendrick 2019-2022.
 // Distributed under the MIT License.
 // (See accompanying file LICENSE in the root of the repository).
 //

--- a/Examples/Includes.cake
+++ b/Examples/Includes.cake
@@ -5,7 +5,7 @@
 //
 
 // For binding arguments.
-#addin nuget:?package=Cake.ArgumentBinder&version=0.3.0
+#addin nuget:?package=Cake.ArgumentBinder&version=2.0.0
 
 using System;
 using System.Linq;

--- a/Examples/Includes.cake
+++ b/Examples/Includes.cake
@@ -1,5 +1,5 @@
 //
-// Copyright Seth Hendrick 2019-2021.
+// Copyright Seth Hendrick 2019-2022.
 // Distributed under the MIT License.
 // (See accompanying file LICENSE in the root of the repository).
 //

--- a/Examples/build.cake
+++ b/Examples/build.cake
@@ -1,5 +1,5 @@
 //
-// Copyright Seth Hendrick 2019-2021.
+// Copyright Seth Hendrick 2019-2022.
 // Distributed under the MIT License.
 // (See accompanying file LICENSE in the root of the repository).
 //

--- a/README.md
+++ b/README.md
@@ -187,7 +187,7 @@ For questions and to discuss ideas & feature requests, use the [GitHub discussio
 
 Versioning
 --------
-Cake.ArgumentBinder's verioning isn't quite semantic verioning.  Rather, the major version (x in x.y.z) is the verion of cake the library was compiled against.  For example, if Cake.ArgumentBinder has a dependency on Cake version 2.0.0, the Cake.ArgumentBinder's version would be 2.y.z.  The minor version (y in x.y.z) will be incremented when a new feature gets added.  The patch (z in x.y.z) will be incremented when a bug fix happens.  We'll try to keep breaking backwards compatiblity to a minimum, and only when a new major version of Cake is released.
+Cake.ArgumentBinder's versioning isn't quite semantic verioning.  Rather, the major version (x in x.y.z) is the version of cake the library was compiled against.  For example, if Cake.ArgumentBinder has a dependency on Cake version 2.0.0, the Cake.ArgumentBinder's version would be 2.y.z.  The minor version (y in x.y.z) will be incremented when a new feature gets added.  The patch (z in x.y.z) will be incremented when a bug fix happens.  We'll try to keep breaking backwards compatibility  to a minimum, and only when a new major version of Cake is released.
 
 License
 --------

--- a/build.cake
+++ b/build.cake
@@ -215,7 +215,7 @@ Task( "update_license" )
     {
         const string currentLicense =
 @"//
-// Copyright Seth Hendrick 2019-2021.
+// Copyright Seth Hendrick 2019-2022.
 // Distributed under the MIT License.
 // (See accompanying file LICENSE in the root of the repository).
 //

--- a/nuspec/Cake.ArgumentBinder.nuspec
+++ b/nuspec/Cake.ArgumentBinder.nuspec
@@ -6,7 +6,7 @@
 >
   <metadata>
     <dependencies>
-      <group targetFramework="netstandard2.0"/>
+      <group targetFramework="netcoreapp3.1"/>
     </dependencies>
     <id>Cake.ArgumentBinder</id>
     <version>0.0.0</version> <!-- Set during build. -->

--- a/src/Cake.ArgumentBinder.Tests/BaseFrostingTask.cs
+++ b/src/Cake.ArgumentBinder.Tests/BaseFrostingTask.cs
@@ -1,5 +1,5 @@
-﻿//
-// Copyright Seth Hendrick 2019-2021.
+//
+// Copyright Seth Hendrick 2019-2022.
 // Distributed under the MIT License.
 // (See accompanying file LICENSE in the root of the repository).
 //

--- a/src/Cake.ArgumentBinder.Tests/Cake.ArgumentBinder.Tests.csproj
+++ b/src/Cake.ArgumentBinder.Tests/Cake.ArgumentBinder.Tests.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Cake.Frosting" Version="1.0.0" />
+    <PackageReference Include="Cake.Frosting" Version="2.0.0" />
     <PackageReference Include="Moq" Version="4.16.1" />
     <PackageReference Include="nunit" Version="3.13.1" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />

--- a/src/Cake.ArgumentBinder.Tests/CakeFrostingRunner.cs
+++ b/src/Cake.ArgumentBinder.Tests/CakeFrostingRunner.cs
@@ -1,5 +1,5 @@
-﻿//
-// Copyright Seth Hendrick 2019-2021.
+//
+// Copyright Seth Hendrick 2019-2022.
 // Distributed under the MIT License.
 // (See accompanying file LICENSE in the root of the repository).
 //

--- a/src/Cake.ArgumentBinder.Tests/IntegrationTests/BooleanArgumentBindTests.cs
+++ b/src/Cake.ArgumentBinder.Tests/IntegrationTests/BooleanArgumentBindTests.cs
@@ -1,5 +1,5 @@
-﻿//
-// Copyright Seth Hendrick 2019-2021.
+//
+// Copyright Seth Hendrick 2019-2022.
 // Distributed under the MIT License.
 // (See accompanying file LICENSE in the root of the repository).
 //

--- a/src/Cake.ArgumentBinder.Tests/IntegrationTests/BooleanArgumentThenEnvironmentVariableBindTests.cs
+++ b/src/Cake.ArgumentBinder.Tests/IntegrationTests/BooleanArgumentThenEnvironmentVariableBindTests.cs
@@ -1,5 +1,5 @@
-﻿//
-// Copyright Seth Hendrick 2019-2021.
+//
+// Copyright Seth Hendrick 2019-2022.
 // Distributed under the MIT License.
 // (See accompanying file LICENSE in the root of the repository).
 //

--- a/src/Cake.ArgumentBinder.Tests/IntegrationTests/BooleanEnvironmentVariableBindTests.cs
+++ b/src/Cake.ArgumentBinder.Tests/IntegrationTests/BooleanEnvironmentVariableBindTests.cs
@@ -1,5 +1,5 @@
-﻿//
-// Copyright Seth Hendrick 2019-2021.
+//
+// Copyright Seth Hendrick 2019-2022.
 // Distributed under the MIT License.
 // (See accompanying file LICENSE in the root of the repository).
 //

--- a/src/Cake.ArgumentBinder.Tests/IntegrationTests/BooleanEnvironmentVariableThenArgumentBindTests.cs
+++ b/src/Cake.ArgumentBinder.Tests/IntegrationTests/BooleanEnvironmentVariableThenArgumentBindTests.cs
@@ -1,5 +1,5 @@
-﻿//
-// Copyright Seth Hendrick 2019-2021.
+//
+// Copyright Seth Hendrick 2019-2022.
 // Distributed under the MIT License.
 // (See accompanying file LICENSE in the root of the repository).
 //

--- a/src/Cake.ArgumentBinder.Tests/IntegrationTests/DirectoryPathBindTests.cs
+++ b/src/Cake.ArgumentBinder.Tests/IntegrationTests/DirectoryPathBindTests.cs
@@ -1,5 +1,5 @@
-﻿//
-// Copyright Seth Hendrick 2019-2021.
+//
+// Copyright Seth Hendrick 2019-2022.
 // Distributed under the MIT License.
 // (See accompanying file LICENSE in the root of the repository).
 //

--- a/src/Cake.ArgumentBinder.Tests/IntegrationTests/EnumBindTests.cs
+++ b/src/Cake.ArgumentBinder.Tests/IntegrationTests/EnumBindTests.cs
@@ -1,5 +1,5 @@
-﻿//
-// Copyright Seth Hendrick 2019-2021.
+//
+// Copyright Seth Hendrick 2019-2022.
 // Distributed under the MIT License.
 // (See accompanying file LICENSE in the root of the repository).
 //

--- a/src/Cake.ArgumentBinder.Tests/IntegrationTests/FilePathBindTests.cs
+++ b/src/Cake.ArgumentBinder.Tests/IntegrationTests/FilePathBindTests.cs
@@ -1,5 +1,5 @@
-﻿//
-// Copyright Seth Hendrick 2019-2021.
+//
+// Copyright Seth Hendrick 2019-2022.
 // Distributed under the MIT License.
 // (See accompanying file LICENSE in the root of the repository).
 //

--- a/src/Cake.ArgumentBinder.Tests/IntegrationTests/IntegerBindTests.cs
+++ b/src/Cake.ArgumentBinder.Tests/IntegrationTests/IntegerBindTests.cs
@@ -1,5 +1,5 @@
-﻿//
-// Copyright Seth Hendrick 2019-2021.
+//
+// Copyright Seth Hendrick 2019-2022.
 // Distributed under the MIT License.
 // (See accompanying file LICENSE in the root of the repository).
 //

--- a/src/Cake.ArgumentBinder.Tests/IntegrationTests/StringBindTests.cs
+++ b/src/Cake.ArgumentBinder.Tests/IntegrationTests/StringBindTests.cs
@@ -1,5 +1,5 @@
-﻿//
-// Copyright Seth Hendrick 2019-2021.
+//
+// Copyright Seth Hendrick 2019-2022.
 // Distributed under the MIT License.
 // (See accompanying file LICENSE in the root of the repository).
 //

--- a/src/Cake.ArgumentBinder.Tests/TestHelpers.cs
+++ b/src/Cake.ArgumentBinder.Tests/TestHelpers.cs
@@ -1,5 +1,5 @@
-﻿//
-// Copyright Seth Hendrick 2019-2021.
+//
+// Copyright Seth Hendrick 2019-2022.
 // Distributed under the MIT License.
 // (See accompanying file LICENSE in the root of the repository).
 //

--- a/src/Cake.ArgumentBinder.Tests/UnitTests/BooleanArgumentAttributeShowDescriptionTests.cs
+++ b/src/Cake.ArgumentBinder.Tests/UnitTests/BooleanArgumentAttributeShowDescriptionTests.cs
@@ -1,4 +1,10 @@
-﻿//
+//
+// Copyright Seth Hendrick 2019-2022.
+// Distributed under the MIT License.
+// (See accompanying file LICENSE in the root of the repository).
+//
+
+//
 // Copyright Seth Hendrick 2019-2021.
 // Distributed under the MIT License.
 // (See accompanying Directory LICENSE in the root of the repository).

--- a/src/Cake.ArgumentBinder.Tests/UnitTests/BooleanArgumentAttributeTests.cs
+++ b/src/Cake.ArgumentBinder.Tests/UnitTests/BooleanArgumentAttributeTests.cs
@@ -1,5 +1,5 @@
-﻿//
-// Copyright Seth Hendrick 2019-2021.
+//
+// Copyright Seth Hendrick 2019-2022.
 // Distributed under the MIT License.
 // (See accompanying file LICENSE in the root of the repository).
 //

--- a/src/Cake.ArgumentBinder.Tests/UnitTests/BooleanArgumentToStringTest.cs
+++ b/src/Cake.ArgumentBinder.Tests/UnitTests/BooleanArgumentToStringTest.cs
@@ -1,4 +1,10 @@
-﻿//
+//
+// Copyright Seth Hendrick 2019-2022.
+// Distributed under the MIT License.
+// (See accompanying file LICENSE in the root of the repository).
+//
+
+//
 // Copyright Seth Hendrick 2019-2021.
 // Distributed under the MIT License.
 // (See accompanying Directory LICENSE in the root of the repository).

--- a/src/Cake.ArgumentBinder.Tests/UnitTests/DirectoryPathArgumentAttributeShowDescriptionTests.cs
+++ b/src/Cake.ArgumentBinder.Tests/UnitTests/DirectoryPathArgumentAttributeShowDescriptionTests.cs
@@ -1,5 +1,5 @@
-﻿//
-// Copyright Seth Hendrick 2019-2021.
+//
+// Copyright Seth Hendrick 2019-2022.
 // Distributed under the MIT License.
 // (See accompanying file LICENSE in the root of the repository).
 //

--- a/src/Cake.ArgumentBinder.Tests/UnitTests/DirectoryPathArgumentAttributeTests.cs
+++ b/src/Cake.ArgumentBinder.Tests/UnitTests/DirectoryPathArgumentAttributeTests.cs
@@ -1,4 +1,10 @@
-﻿//
+//
+// Copyright Seth Hendrick 2019-2022.
+// Distributed under the MIT License.
+// (See accompanying file LICENSE in the root of the repository).
+//
+
+//
 // Copyright Seth Hendrick 2019-2021.
 // Distributed under the MIT License.
 // (See accompanying Directory LICENSE in the root of the repository).

--- a/src/Cake.ArgumentBinder.Tests/UnitTests/EnumArgumentAttributeShowDescriptionTests.cs
+++ b/src/Cake.ArgumentBinder.Tests/UnitTests/EnumArgumentAttributeShowDescriptionTests.cs
@@ -1,5 +1,5 @@
-﻿//
-// Copyright Seth Hendrick 2019-2021.
+//
+// Copyright Seth Hendrick 2019-2022.
 // Distributed under the MIT License.
 // (See accompanying file LICENSE in the root of the repository).
 //

--- a/src/Cake.ArgumentBinder.Tests/UnitTests/EnumArgumentAttributeTests.cs
+++ b/src/Cake.ArgumentBinder.Tests/UnitTests/EnumArgumentAttributeTests.cs
@@ -1,5 +1,5 @@
-﻿//
-// Copyright Seth Hendrick 2019-2021.
+//
+// Copyright Seth Hendrick 2019-2022.
 // Distributed under the MIT License.
 // (See accompanying file LICENSE in the root of the repository).
 //

--- a/src/Cake.ArgumentBinder.Tests/UnitTests/FileArgumentAttributeTests.cs
+++ b/src/Cake.ArgumentBinder.Tests/UnitTests/FileArgumentAttributeTests.cs
@@ -1,5 +1,5 @@
-﻿//
-// Copyright Seth Hendrick 2019-2021.
+//
+// Copyright Seth Hendrick 2019-2022.
 // Distributed under the MIT License.
 // (See accompanying file LICENSE in the root of the repository).
 //

--- a/src/Cake.ArgumentBinder.Tests/UnitTests/FilePathArgumentAttributeShowDescriptionTests.cs
+++ b/src/Cake.ArgumentBinder.Tests/UnitTests/FilePathArgumentAttributeShowDescriptionTests.cs
@@ -1,5 +1,5 @@
-﻿//
-// Copyright Seth Hendrick 2019-2021.
+//
+// Copyright Seth Hendrick 2019-2022.
 // Distributed under the MIT License.
 // (See accompanying file LICENSE in the root of the repository).
 //

--- a/src/Cake.ArgumentBinder.Tests/UnitTests/IntegerArgumentAttributeShowDescriptionTests.cs
+++ b/src/Cake.ArgumentBinder.Tests/UnitTests/IntegerArgumentAttributeShowDescriptionTests.cs
@@ -1,5 +1,5 @@
-﻿//
-// Copyright Seth Hendrick 2019-2021.
+//
+// Copyright Seth Hendrick 2019-2022.
 // Distributed under the MIT License.
 // (See accompanying file LICENSE in the root of the repository).
 //

--- a/src/Cake.ArgumentBinder.Tests/UnitTests/IntegerArgumentAttributeTests.cs
+++ b/src/Cake.ArgumentBinder.Tests/UnitTests/IntegerArgumentAttributeTests.cs
@@ -1,5 +1,5 @@
-﻿//
-// Copyright Seth Hendrick 2019-2021.
+//
+// Copyright Seth Hendrick 2019-2022.
 // Distributed under the MIT License.
 // (See accompanying file LICENSE in the root of the repository).
 //

--- a/src/Cake.ArgumentBinder.Tests/UnitTests/MockICakeArgumentsExtensions.cs
+++ b/src/Cake.ArgumentBinder.Tests/UnitTests/MockICakeArgumentsExtensions.cs
@@ -1,5 +1,5 @@
-﻿//
-// Copyright Seth Hendrick 2019-2021.
+//
+// Copyright Seth Hendrick 2019-2022.
 // Distributed under the MIT License.
 // (See accompanying file LICENSE in the root of the repository).
 //

--- a/src/Cake.ArgumentBinder.Tests/UnitTests/StringArgumentAttributeShowDescriptionTests.cs
+++ b/src/Cake.ArgumentBinder.Tests/UnitTests/StringArgumentAttributeShowDescriptionTests.cs
@@ -1,5 +1,5 @@
-﻿//
-// Copyright Seth Hendrick 2019-2021.
+//
+// Copyright Seth Hendrick 2019-2022.
 // Distributed under the MIT License.
 // (See accompanying file LICENSE in the root of the repository).
 //

--- a/src/Cake.ArgumentBinder.Tests/UnitTests/StringArgumentAttributeTests.cs
+++ b/src/Cake.ArgumentBinder.Tests/UnitTests/StringArgumentAttributeTests.cs
@@ -1,5 +1,5 @@
-﻿//
-// Copyright Seth Hendrick 2019-2021.
+//
+// Copyright Seth Hendrick 2019-2022.
 // Distributed under the MIT License.
 // (See accompanying file LICENSE in the root of the repository).
 //

--- a/src/Cake.ArgumentBinder.Tests/UnitTests/StringArgumentToStringTest.cs
+++ b/src/Cake.ArgumentBinder.Tests/UnitTests/StringArgumentToStringTest.cs
@@ -1,4 +1,10 @@
-﻿//
+//
+// Copyright Seth Hendrick 2019-2022.
+// Distributed under the MIT License.
+// (See accompanying file LICENSE in the root of the repository).
+//
+
+//
 // Copyright Seth Hendrick 2019-2021.
 // Distributed under the MIT License.
 // (See accompanying Directory LICENSE in the root of the repository).

--- a/src/Cake.ArgumentBinder/ArgumentBinder.cs
+++ b/src/Cake.ArgumentBinder/ArgumentBinder.cs
@@ -1,5 +1,5 @@
-﻿//
-// Copyright Seth Hendrick 2019-2021.
+//
+// Copyright Seth Hendrick 2019-2022.
 // Distributed under the MIT License.
 // (See accompanying file LICENSE in the root of the repository).
 //

--- a/src/Cake.ArgumentBinder/ArgumentBinderAliases.ArgumentConfigToString.cs
+++ b/src/Cake.ArgumentBinder/ArgumentBinderAliases.ArgumentConfigToString.cs
@@ -1,5 +1,5 @@
 //
-// Copyright Seth Hendrick 2019-2021.
+// Copyright Seth Hendrick 2019-2022.
 // Distributed under the MIT License.
 // (See accompanying file LICENSE in the root of the repository).
 //

--- a/src/Cake.ArgumentBinder/ArgumentBinderAliases.FromArguments.cs
+++ b/src/Cake.ArgumentBinder/ArgumentBinderAliases.FromArguments.cs
@@ -1,5 +1,5 @@
 //
-// Copyright Seth Hendrick 2019-2021.
+// Copyright Seth Hendrick 2019-2022.
 // Distributed under the MIT License.
 // (See accompanying file LICENSE in the root of the repository).
 //

--- a/src/Cake.ArgumentBinder/ArgumentBinderAliases.cs
+++ b/src/Cake.ArgumentBinder/ArgumentBinderAliases.cs
@@ -1,5 +1,5 @@
 //
-// Copyright Seth Hendrick 2019-2021.
+// Copyright Seth Hendrick 2019-2022.
 // Distributed under the MIT License.
 // (See accompanying file LICENSE in the root of the repository).
 //

--- a/src/Cake.ArgumentBinder/BaseAttribute.cs
+++ b/src/Cake.ArgumentBinder/BaseAttribute.cs
@@ -1,5 +1,5 @@
-﻿//
-// Copyright Seth Hendrick 2019-2021.
+//
+// Copyright Seth Hendrick 2019-2022.
 // Distributed under the MIT License.
 // (See accompanying file LICENSE in the root of the repository).
 //

--- a/src/Cake.ArgumentBinder/BasePathAttribute.cs
+++ b/src/Cake.ArgumentBinder/BasePathAttribute.cs
@@ -1,5 +1,5 @@
-﻿//
-// Copyright Seth Hendrick 2019-2021.
+//
+// Copyright Seth Hendrick 2019-2022.
 // Distributed under the MIT License.
 // (See accompanying file LICENSE in the root of the repository).
 //

--- a/src/Cake.ArgumentBinder/Binders/BaseBinder.cs
+++ b/src/Cake.ArgumentBinder/Binders/BaseBinder.cs
@@ -1,5 +1,5 @@
-﻿//
-// Copyright Seth Hendrick 2019-2021.
+//
+// Copyright Seth Hendrick 2019-2022.
 // Distributed under the MIT License.
 // (See accompanying file LICENSE in the root of the repository).
 //

--- a/src/Cake.ArgumentBinder/Binders/BooleanArgumentBinder.cs
+++ b/src/Cake.ArgumentBinder/Binders/BooleanArgumentBinder.cs
@@ -1,5 +1,5 @@
-﻿//
-// Copyright Seth Hendrick 2019-2021.
+//
+// Copyright Seth Hendrick 2019-2022.
 // Distributed under the MIT License.
 // (See accompanying file LICENSE in the root of the repository).
 //

--- a/src/Cake.ArgumentBinder/Binders/DirectoryPathArgumentBinder.cs
+++ b/src/Cake.ArgumentBinder/Binders/DirectoryPathArgumentBinder.cs
@@ -1,5 +1,5 @@
-﻿//
-// Copyright Seth Hendrick 2019-2021.
+//
+// Copyright Seth Hendrick 2019-2022.
 // Distributed under the MIT License.
 // (See accompanying file LICENSE in the root of the repository).
 //

--- a/src/Cake.ArgumentBinder/Binders/EnumArgumentBinder.cs
+++ b/src/Cake.ArgumentBinder/Binders/EnumArgumentBinder.cs
@@ -1,5 +1,5 @@
-﻿//
-// Copyright Seth Hendrick 2019-2021.
+//
+// Copyright Seth Hendrick 2019-2022.
 // Distributed under the MIT License.
 // (See accompanying file LICENSE in the root of the repository).
 //

--- a/src/Cake.ArgumentBinder/Binders/FilePathArgumentBinder.cs
+++ b/src/Cake.ArgumentBinder/Binders/FilePathArgumentBinder.cs
@@ -1,5 +1,5 @@
-﻿//
-// Copyright Seth Hendrick 2019-2021.
+//
+// Copyright Seth Hendrick 2019-2022.
 // Distributed under the MIT License.
 // (See accompanying file LICENSE in the root of the repository).
 //

--- a/src/Cake.ArgumentBinder/Binders/IntegerArgumentBinder.cs
+++ b/src/Cake.ArgumentBinder/Binders/IntegerArgumentBinder.cs
@@ -1,5 +1,5 @@
-﻿//
-// Copyright Seth Hendrick 2019-2021.
+//
+// Copyright Seth Hendrick 2019-2022.
 // Distributed under the MIT License.
 // (See accompanying file LICENSE in the root of the repository).
 //

--- a/src/Cake.ArgumentBinder/Binders/StringArgumentBinder.cs
+++ b/src/Cake.ArgumentBinder/Binders/StringArgumentBinder.cs
@@ -1,5 +1,5 @@
-﻿//
-// Copyright Seth Hendrick 2019-2021.
+//
+// Copyright Seth Hendrick 2019-2022.
 // Distributed under the MIT License.
 // (See accompanying file LICENSE in the root of the repository).
 //

--- a/src/Cake.ArgumentBinder/BooleanArgumentAttribute.cs
+++ b/src/Cake.ArgumentBinder/BooleanArgumentAttribute.cs
@@ -1,5 +1,5 @@
-﻿//
-// Copyright Seth Hendrick 2019-2021.
+//
+// Copyright Seth Hendrick 2019-2022.
 // Distributed under the MIT License.
 // (See accompanying file LICENSE in the root of the repository).
 //

--- a/src/Cake.ArgumentBinder/Cake.ArgumentBinder.csproj
+++ b/src/Cake.ArgumentBinder/Cake.ArgumentBinder.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <noWarn>1591,1573</noWarn>
   </PropertyGroup>

--- a/src/Cake.ArgumentBinder/Cake.ArgumentBinder.csproj
+++ b/src/Cake.ArgumentBinder/Cake.ArgumentBinder.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Cake.Core" Version="1.0.0" />
+    <PackageReference Include="Cake.Core" Version="2.0.0" />
   </ItemGroup>
 
 </Project>

--- a/src/Cake.ArgumentBinder/DirectoryPathArgumentAttribute.cs
+++ b/src/Cake.ArgumentBinder/DirectoryPathArgumentAttribute.cs
@@ -1,5 +1,5 @@
-﻿//
-// Copyright Seth Hendrick 2019-2021.
+//
+// Copyright Seth Hendrick 2019-2022.
 // Distributed under the MIT License.
 // (See accompanying file LICENSE in the root of the repository).
 //

--- a/src/Cake.ArgumentBinder/EnumArgumentAttribute.cs
+++ b/src/Cake.ArgumentBinder/EnumArgumentAttribute.cs
@@ -1,5 +1,5 @@
-﻿//
-// Copyright Seth Hendrick 2019-2021.
+//
+// Copyright Seth Hendrick 2019-2022.
 // Distributed under the MIT License.
 // (See accompanying file LICENSE in the root of the repository).
 //

--- a/src/Cake.ArgumentBinder/Enums.cs
+++ b/src/Cake.ArgumentBinder/Enums.cs
@@ -1,5 +1,5 @@
-﻿//
-// Copyright Seth Hendrick 2019-2021.
+//
+// Copyright Seth Hendrick 2019-2022.
 // Distributed under the MIT License.
 // (See accompanying file LICENSE in the root of the repository).
 //

--- a/src/Cake.ArgumentBinder/Exceptions.cs
+++ b/src/Cake.ArgumentBinder/Exceptions.cs
@@ -1,5 +1,5 @@
-﻿//
-// Copyright Seth Hendrick 2019-2021.
+//
+// Copyright Seth Hendrick 2019-2022.
 // Distributed under the MIT License.
 // (See accompanying file LICENSE in the root of the repository).
 //

--- a/src/Cake.ArgumentBinder/FilePathArgumentAttribute.cs
+++ b/src/Cake.ArgumentBinder/FilePathArgumentAttribute.cs
@@ -1,5 +1,5 @@
-﻿//
-// Copyright Seth Hendrick 2019-2021.
+//
+// Copyright Seth Hendrick 2019-2022.
 // Distributed under the MIT License.
 // (See accompanying file LICENSE in the root of the repository).
 //

--- a/src/Cake.ArgumentBinder/IArgumentAttribute.cs
+++ b/src/Cake.ArgumentBinder/IArgumentAttribute.cs
@@ -1,5 +1,5 @@
 //
-// Copyright Seth Hendrick 2019-2021.
+// Copyright Seth Hendrick 2019-2022.
 // Distributed under the MIT License.
 // (See accompanying file LICENSE in the root of the repository).
 //

--- a/src/Cake.ArgumentBinder/IntegerArgumentAttribute.cs
+++ b/src/Cake.ArgumentBinder/IntegerArgumentAttribute.cs
@@ -1,5 +1,5 @@
-﻿//
-// Copyright Seth Hendrick 2019-2021.
+//
+// Copyright Seth Hendrick 2019-2022.
 // Distributed under the MIT License.
 // (See accompanying file LICENSE in the root of the repository).
 //

--- a/src/Cake.ArgumentBinder/Properties/AssemblyInfo.cs
+++ b/src/Cake.ArgumentBinder/Properties/AssemblyInfo.cs
@@ -1,5 +1,5 @@
-﻿//
-// Copyright Seth Hendrick 2019-2021.
+//
+// Copyright Seth Hendrick 2019-2022.
 // Distributed under the MIT License.
 // (See accompanying file LICENSE in the root of the repository).
 //

--- a/src/Cake.ArgumentBinder/StringArgumentAttribute.cs
+++ b/src/Cake.ArgumentBinder/StringArgumentAttribute.cs
@@ -1,5 +1,5 @@
-﻿//
-// Copyright Seth Hendrick 2019-2021.
+//
+// Copyright Seth Hendrick 2019-2022.
 // Distributed under the MIT License.
 // (See accompanying file LICENSE in the root of the repository).
 //

--- a/src/Cake.ArgumentBinder/TaskExtensions.cs
+++ b/src/Cake.ArgumentBinder/TaskExtensions.cs
@@ -1,5 +1,5 @@
 //
-// Copyright Seth Hendrick 2019-2021.
+// Copyright Seth Hendrick 2019-2022.
 // Distributed under the MIT License.
 // (See accompanying file LICENSE in the root of the repository).
 //


### PR DESCRIPTION
Finally got around to this one.  Cake.ArgumentBinder now targets Cake version 2.0.0 instead of 1.0.0.  Now users of the addin should no longer get warnings.

No code changes, just mostly house-keeping.
- License header updated to 2022 (in hindsight, I probably should have done that on a separate branch, oh well).
- csproj and nuspec now targets netcoreapp3.1.
- Use new DotNet methods instead of DotNetCore methods in build.cake.
- Upgrade all build.cake dependencies to latest versions.

Quick aside, while Cake 2.0.0 suppots .NET 5, since .NET 5 is now end-of-life, I ended up not multi-targeting it.  Just supports Netcore3.1.